### PR TITLE
All rights not reserved

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Works only on 10.6.6 and up
 This is licensed under MIT. Here is some legal jargon:
 
 Copyright (c) 2011 Alex Zielenski
-All Rights Reserved
+Copyright (c) 2012 Travis Tilley
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the

--- a/StartAtLoginController.h
+++ b/StartAtLoginController.h
@@ -1,6 +1,5 @@
 // Copyright (c) 2011 Alex Zielenski
 // Copyright (c) 2012 Travis Tilley
-// All Rights Reserved
 //
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the

--- a/StartAtLoginController.m
+++ b/StartAtLoginController.m
@@ -1,6 +1,5 @@
 // Copyright (c) 2011 Alex Zielenski
 // Copyright (c) 2012 Travis Tilley
-// All Rights Reserved
 //
 // Permission is hereby granted, free of charge, to any person obtaining
 // a copy of this software and associated documentation files (the


### PR DESCRIPTION
A small quibble: The license information at the top of the source code currently bears the standard boilerplate

```
All rights reserved
```

before the MIT license. These are mutually exclusive. By saying that people may freely distribute copies of your work subject only to the condition that they include that same license in those copies, you're forfeiting the exclusive right to make copies of your work. You can't also say that you **reserve** those same rights. `</pedantry>`

Thanks for all your work on this fine project.
